### PR TITLE
Add MCP POST tests

### DIFF
--- a/tests/fetch-equation.test.js
+++ b/tests/fetch-equation.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+module.exports = async function() {
+  const code = fs.readFileSync(path.join(__dirname, '../src/overleaf/background.js'), 'utf8');
+
+  const sandbox = {
+    chrome: {
+      runtime: {
+        onInstalled: { addListener: () => {} },
+        onMessage: { addListener: () => {} }
+      },
+      storage: {
+        sync: {
+          get: async () => ({ apiUrl: 'http://localhost:1234', apiEndpoint: '/mcp' })
+        }
+      }
+    },
+    fetch: async (url, options) => {
+      sandbox.called = { url, options };
+      return { ok: true, json: async () => ({ result: { latex: 'ok' } }) };
+    },
+    console
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+  const fetchEquation = sandbox.fetchEquation;
+  assert.strictEqual(typeof fetchEquation, 'function', 'fetchEquation should be defined');
+
+  await fetchEquation({ text: 'E=mc^2', format: 'display', numbered: true });
+
+  const { url, options } = sandbox.called;
+  assert.strictEqual(url, 'http://localhost:1234/mcp');
+  const body = JSON.parse(options.body);
+  assert.deepStrictEqual(body, {
+    type: 'ExecuteTool',
+    tool: 'generate-latex-equation',
+    parameters: {
+      description: 'E=mc^2',
+      format: 'display',
+      numbered: true
+    }
+  });
+  console.log('fetchEquation test passed');
+};

--- a/tests/mcp-post.test.js
+++ b/tests/mcp-post.test.js
@@ -1,0 +1,55 @@
+const http = require('http');
+const assert = require('assert');
+
+module.exports = () => new Promise((resolve, reject) => {
+  const expectedReq = {
+    type: 'ExecuteTool',
+    tool: 'generate-latex-equation',
+    parameters: {
+      description: 'test equation',
+      format: 'display',
+      numbered: false
+    }
+  };
+
+  const expectedRes = { result: { latex: 'x=1' } };
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/mcp') {
+      res.statusCode = 404;
+      return res.end();
+    }
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const parsed = JSON.parse(body);
+        assert.deepStrictEqual(parsed, expectedReq);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(expectedRes));
+      } catch (err) {
+        reject(err);
+        server.close();
+      }
+    });
+  });
+
+  server.listen(0, async () => {
+    const { port } = server.address();
+    try {
+      const resp = await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(expectedReq)
+      });
+      const json = await resp.json();
+      assert.deepStrictEqual(json, expectedRes);
+      console.log('mcp-post test passed');
+      resolve();
+    } catch (err) {
+      reject(err);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,8 +1,20 @@
-try {
-  require('./equation-tool.test.js');
-  console.log('All tests passed');
-} catch (err) {
-  console.error('Tests failed');
-  console.error(err);
-  process.exit(1);
+async function runTest(mod) {
+  if (typeof mod === 'function') {
+    await mod();
+  } else if (mod && typeof mod.then === 'function') {
+    await mod;
+  }
 }
+
+(async () => {
+  try {
+    await runTest(require('./equation-tool.test.js'));
+    await runTest(require('./mcp-post.test.js'));
+    await runTest(require('./fetch-equation.test.js'));
+    console.log('All tests passed');
+  } catch (err) {
+    console.error('Tests failed');
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a test mocking POST `/mcp` that verifies ExecuteTool payload and response
- add `fetchEquation` test to confirm posted body shape
- update test runner to handle async tests

## Testing
- `npm test`